### PR TITLE
Fix: Add missing fill color to KML styles

### DIFF
--- a/web/styles.kml
+++ b/web/styles.kml
@@ -15,7 +15,7 @@
 
     <Style id="caminataStyle">
       <LineStyle><color>ff00ff00</color><width>3.5</width></LineStyle>
-      <PolyStyle><fill>1</fill></PolyStyle>
+      <PolyStyle><color>8000ff00</color><fill>1</fill></PolyStyle>
     </Style>
 
     <Style id="greenFill">


### PR DESCRIPTION
The caminataStyle in web/styles.kml was missing a <color> definition for its <PolyStyle>, causing polygons using this style to appear white in Google Earth.

This change adds a semi-transparent green fill color to caminataStyle. Other styles were reviewed and confirmed to be correctly defined for their intended fill behavior.