### PR TITLE
Fix styles.kml default style

### DIFF
--- a/web/styles.kml
+++ b/web/styles.kml
@@ -23,10 +23,9 @@
       <PolyStyle><color>8000ff00</color><fill>1</fill></PolyStyle>
     </Style>
 
-    <Style id="defaultStyle">
-      <LineStyle><color>ff0000ff</color><width>1</LineStyle>
-      <PolyStyle><fill>0</fill></PolyStyle>
-    </Style>
+      <Style id="defaultStyle">
+        <LineStyle><color>ff0000ff</color><width>1</width></LineStyle>
+        <PolyStyle><fill>0</fill></PolyStyle>
+      </Style>
 
-  </Document>
-</kml>
+  </Document></kml>


### PR DESCRIPTION
## Summary
- fix `styles.kml` so default style contains proper `<width>` tag

## Testing
- `curl -I https://lagobello.github.io/lagobello-drawings/web/styles.kml | head`


------
https://chatgpt.com/codex/tasks/task_e_686ed2ace408832eba5036022fd7b2ce