### PR TITLE
Fix layer order below drone map

### DIFF
--- a/scripts/build_layers.sh
+++ b/scripts/build_layers.sh
@@ -95,7 +95,7 @@ export_layer () {        # $1=SQL where  $2=stem  (no ext)
     # using an absolute URL that includes the style ID.
     sed -e 's|<Style><LineStyle><color>ff0000ff</color></LineStyle><PolyStyle><fill>0</fill></PolyStyle></Style>|<styleUrl>https://lagobello.github.io/lagobello-drawings/web/styles.kml#'${STYLE_NAME}'</styleUrl>|g' \
         -e '/<NetworkLink><Link><href>https:\/\/lagobello.github.io\/lagobello-drawings\/web\/styles.kml<\/href><\/Link><\/NetworkLink>/d' "$KML_TMP" | \
-    sed -e 's|</styleUrl>|</styleUrl>\n        <gx:drawOrder>100</gx:drawOrder>|g' \
+    sed -e 's|</styleUrl>|</styleUrl>\n        <gx:drawOrder>100</gx:drawOrder>\n        <altitudeMode>clampToGround</altitudeMode>|g' \
         -e 's|<kml |<kml xmlns:gx="http://www.google.com/kml/ext/2.2" |' > "$KML"
 
     rm "$KML_TMP"


### PR DESCRIPTION
## Summary
- export KML overlays with `<altitudeMode>` so map layers sit above drone imagery

## Testing
- `ogrinfo --version`


------
https://chatgpt.com/codex/tasks/task_e_686f064eccd0832e8d0c87aeca496200