### PR TITLE
Fix altitude not applying in generated KML

### DIFF
--- a/scripts/build_layers.sh
+++ b/scripts/build_layers.sh
@@ -97,9 +97,10 @@ export_layer () {        # $1=SQL where  $2=stem  (no ext)
         -e '/<NetworkLink><Link><href>https:\/\/lagobello.github.io\/lagobello-drawings\/web\/styles.kml<\/href><\/Link><\/NetworkLink>/d' "$KML_TMP" | \
     sed -e '/<gx:drawOrder>/d' \
         -e '/<altitudeMode>clampToGround<\/altitudeMode>/d' \
-        -e 's|<Polygon>|<Polygon><altitudeMode>relativeToGround</altitudeMode><gx:altitudeOffset>1</gx:altitudeOffset>|g' \
-        -e 's|<LineString>|<LineString><altitudeMode>relativeToGround</altitudeMode><gx:altitudeOffset>1</gx:altitudeOffset>|g' \
-        -e 's|<Point>|<Point><altitudeMode>relativeToGround</altitudeMode><gx:altitudeOffset>1</gx:altitudeOffset>|g' \
+        -e 's|<Polygon>|<Polygon><altitudeMode>relativeToGround</altitudeMode>|g' \
+        -e 's|<LineString>|<LineString><altitudeMode>relativeToGround</altitudeMode>|g' \
+        -e 's|<Point>|<Point><altitudeMode>relativeToGround</altitudeMode>|g' \
+        -e 's|\([0-9.-]*,[0-9.-]*\)\(,[0-9.-]*\)?\([ <]\)|\1,1\3|g' \
         -e 's|<kml |<kml xmlns:gx="http://www.google.com/kml/ext/2.2" |' > "$KML"
 
     rm "$KML_TMP"


### PR DESCRIPTION
## Summary
- convert coordinates in generated KML files to use altitude `1`
- drop `gx:altitudeOffset` as it's no longer needed

## Testing
- `apt-get update`
- `apt-get install -y gdal-bin python3-gdal git-lfs`
- `git lfs pull` *(fails: missing protocol)*


------
https://chatgpt.com/codex/tasks/task_e_686f357cde44832eb95dddbb7f9f32e2