### PR TITLE
Fix altitude sed regex

### DIFF
--- a/scripts/build_layers.sh
+++ b/scripts/build_layers.sh
@@ -100,7 +100,7 @@ export_layer () {        # $1=SQL where  $2=stem  (no ext)
         -e 's|<Polygon>|<Polygon><altitudeMode>relativeToGround</altitudeMode>|g' \
         -e 's|<LineString>|<LineString><altitudeMode>relativeToGround</altitudeMode>|g' \
         -e 's|<Point>|<Point><altitudeMode>relativeToGround</altitudeMode>|g' \
-        -e 's|\([0-9.-]*,[0-9.-]*\)\(,[0-9.-]*\)?\([ <]\)|\1,1\3|g' \
+        -e 's|\([0-9.-]*,[0-9.-]*\)\(,[0-9.-]*\)\?\([ <]\)|\1,1\3|g' \
         -e 's|<kml |<kml xmlns:gx="http://www.google.com/kml/ext/2.2" |' > "$KML"
 
     rm "$KML_TMP"


### PR DESCRIPTION
## Summary
- escape `?` in KML altitude regex so that coordinates get a default z value

## Testing
- `sudo apt install gdal-bin python3-gdal git-lfs -y`
- `git lfs pull` *(fails: missing protocol)*

------
https://chatgpt.com/codex/tasks/task_e_686f3ce96724832e860be8032e28bd4e